### PR TITLE
Update and fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 http://hg.q-continuum.net/sound_lib/archive/tip.tar.gz
 requests
-urllib
+configoobj
+validate


### PR DESCRIPTION
urllib is part of the standard library, and configobj and validate are not; they need to be included
